### PR TITLE
Add ACF field integration for UTM Builder: retrieve and localize mediums

### DIFF
--- a/wp-content/themes/cno-starter-theme/page-templates/utm-builder.php
+++ b/wp-content/themes/cno-starter-theme/page-templates/utm-builder.php
@@ -9,6 +9,43 @@ use ChoctawNation\Asset_Loader;
 use ChoctawNation\Enqueue_Type;
 
 new Asset_Loader( 'utmBuilder', Enqueue_Type::both, 'pages' );
+
+/**
+ * Pass ACF repeater data to the UTM Builder script.
+ *
+ * IMPORTANT: this runs in the template file (before get_header), not inside a
+ * `wp_enqueue_scripts` callback, because that action has already fired by the
+ * time WordPress resolves and executes page templates.
+ *
+ * ACF field structure:
+ *   Repeater: utm_mediums
+ *   └─ Text:  mediums
+ */
+$acf_mediums = array();
+if ( function_exists( 'get_field' ) ) {
+	$page_id          = get_queried_object_id();
+	$utm_mediums_rows = get_field( 'utm_mediums', $page_id );
+	if ( is_array( $utm_mediums_rows ) ) {
+		foreach ( $utm_mediums_rows as $row ) {
+			if ( empty( $row['mediums'] ) ) {
+				continue;
+			}
+			$clean_medium = sanitize_text_field( $row['mediums'] );
+			if ( '' !== $clean_medium ) {
+				$acf_mediums[] = $clean_medium;
+			}
+		}
+	}
+}
+
+wp_localize_script(
+	'utmBuilder',
+	'utmBuilderData',
+	array(
+		'mediums' => $acf_mediums,
+	)
+);
+
 get_header();
 ?>
 

--- a/wp-content/themes/cno-starter-theme/page-templates/utm-builder.php
+++ b/wp-content/themes/cno-starter-theme/page-templates/utm-builder.php
@@ -13,9 +13,8 @@ new Asset_Loader( 'utmBuilder', Enqueue_Type::both, 'pages' );
 /**
  * Pass ACF repeater data to the UTM Builder script.
  *
- * IMPORTANT: this runs in the template file (before get_header), not inside a
- * `wp_enqueue_scripts` callback, because that action has already fired by the
- * time WordPress resolves and executes page templates.
+ * This runs in the template file before `get_header()`, so the page-specific
+ * ACF data can be prepared and localized for the script used by this template.
  *
  * ACF field structure:
  *   Repeater: utm_mediums

--- a/wp-content/themes/cno-starter-theme/src/js/utm-builder/state.ts
+++ b/wp-content/themes/cno-starter-theme/src/js/utm-builder/state.ts
@@ -1,3 +1,4 @@
+import { sanitizeMedium } from './utils';
 import type { UtmRow } from './types';
 
 /**
@@ -14,9 +15,9 @@ const fallbackMediums = [ 'youtube', 'ott', 'sem', 'display', 'rgd', 'audio' ];
  * Users may add or remove entries at runtime.
  */
 const localizedMediums = Array.isArray( window.utmBuilderData?.mediums )
-	? window.utmBuilderData.mediums.filter( ( medium ) =>
-			Boolean( String( medium || '' ).trim() )
-	  )
+	? window.utmBuilderData.mediums
+			.map( ( medium ) => sanitizeMedium( String( medium || '' ) ) )
+			.filter( Boolean )
 	: [];
 
 export const defaultMediums: string[] = Array.from(

--- a/wp-content/themes/cno-starter-theme/src/js/utm-builder/state.ts
+++ b/wp-content/themes/cno-starter-theme/src/js/utm-builder/state.ts
@@ -1,17 +1,27 @@
 import type { UtmRow } from './types';
 
 /**
- * The set of media channels (utm_medium values) available for row generation.
- * Users may add or remove entries at runtime. Defaults are restored on page load.
+ * Fallback mediums used when the ACF repeater field provides no data.
+ * These match the default channels used in most campaigns.
  */
-export const defaultMediums = [
-	'youtube',
-	'ott',
-	'sem',
-	'display',
-	'rgd',
-	'audio',
-];
+const fallbackMediums = [ 'youtube', 'ott', 'sem', 'display', 'rgd', 'audio' ];
+
+/**
+ * The set of media channels (utm_medium values) available for row generation.
+ * Built from the fallback list plus the `utm_mediums` ACF Repeater field
+ * (via wp_localize_script). This guarantees the fallback defaults are always
+ * present while still allowing ACF to add additional entries.
+ * Users may add or remove entries at runtime.
+ */
+const localizedMediums = Array.isArray( window.utmBuilderData?.mediums )
+	? window.utmBuilderData.mediums.filter( ( medium ) =>
+			Boolean( String( medium || '' ).trim() )
+	  )
+	: [];
+
+export const defaultMediums: string[] = Array.from(
+	new Set( [ ...fallbackMediums, ...localizedMediums ] )
+);
 
 /** Mutable list of currently active mediums. */
 export let mediums: string[] = [ ...defaultMediums ];

--- a/wp-content/themes/cno-starter-theme/src/js/utm-builder/types.ts
+++ b/wp-content/themes/cno-starter-theme/src/js/utm-builder/types.ts
@@ -1,4 +1,17 @@
 /**
+ * Data localized from PHP via wp_localize_script( 'utmBuilder', 'utmBuilderData', ... ).
+ * Available on window before the script executes.
+ */
+declare global {
+	interface Window {
+		utmBuilderData?: {
+			/** Medium values sourced from the `utm_mediums` ACF Repeater field. */
+			mediums: string[];
+		};
+	}
+}
+
+/**
  * Represents a single UTM-tagged URL row in the builder table.
  * Each row captures the inputs used to construct one long URL.
  */


### PR DESCRIPTION
This pull request enhances the UTM Builder feature by integrating ACF (Advanced Custom Fields) repeater data from WordPress into the JavaScript application, allowing dynamic configuration of available UTM mediums. It ensures that campaign managers can manage the list of mediums via the WordPress admin, while always falling back to a default set if none are provided.

**Integration of ACF Data with UTM Builder:**

- [`utm-builder.php`](diffhunk://#diff-a156600633e9eae16623bcd1695c8f8bfbffa85f2402e17acd93ed05971b7afbR12-R48): Fetches the `utm_mediums` repeater data using ACF, sanitizes it, and passes it to the front-end via `wp_localize_script`, making the list of mediums available to JavaScript.

**JavaScript State Management Updates:**

- `state.ts`: 
  - Introduces a `fallbackMediums` array with default values.
  - Updates `defaultMediums` to merge ACF-provided mediums (from `window.utmBuilderData.mediums`) with the defaults, ensuring no duplicates and always including the fallback values.

**Type Declarations for Localized Data:**

- [`types.ts`](diffhunk://#diff-ac8c0339b1ecc4e762f6aef353860b25b2f4a872b74674587d23c28f2530f7e8R1-R13): Declares the shape of `window.utmBuilderData` for TypeScript, ensuring type safety when accessing localized data in the JS app.

These changes make the UTM Builder more flexible and maintainable by allowing non-developers to update campaign mediums directly from the WordPress backend.